### PR TITLE
Make unowned member variables weak optional in ViewPortJob.

### DIFF
--- a/Source/Charts/Jobs/AnimatedMoveViewJob.swift
+++ b/Source/Charts/Jobs/AnimatedMoveViewJob.swift
@@ -16,12 +16,13 @@ open class AnimatedMoveViewJob: AnimatedViewPortJob
 {
     internal override func animationUpdate()
     {
+        guard let viewPortHandler = viewPortHandler, let view = view else { return }
         var pt = CGPoint(
             x: xOrigin + (CGFloat(xValue) - xOrigin) * phase,
             y: yOrigin + (CGFloat(yValue) - yOrigin) * phase
         )
         
-        transformer.pointValueToPixel(&pt)
+        transformer?.pointValueToPixel(&pt)
         viewPortHandler.centerViewPort(pt: pt, chart: view)
     }
 }

--- a/Source/Charts/Jobs/AnimatedZoomViewJob.swift
+++ b/Source/Charts/Jobs/AnimatedZoomViewJob.swift
@@ -64,7 +64,7 @@ open class AnimatedZoomViewJob: AnimatedViewPortJob
     {
         let scaleX = xOrigin + (self.scaleX - xOrigin) * phase
         let scaleY = yOrigin + (self.scaleY - yOrigin) * phase
-        
+        guard let viewPortHandler = viewPortHandler, let view = view else { return }
         var matrix = viewPortHandler.setZoom(scaleX: scaleX, scaleY: scaleY)
         viewPortHandler.refresh(newMatrix: matrix, chart: view, invalidate: false)
         
@@ -76,7 +76,7 @@ open class AnimatedZoomViewJob: AnimatedViewPortJob
             y: zoomOriginY + ((zoomCenterY + valsInView / 2.0) - zoomOriginY) * phase
         )
         
-        transformer.pointValueToPixel(&pt)
+        transformer?.pointValueToPixel(&pt)
         
         matrix = viewPortHandler.translate(pt: pt)
         viewPortHandler.refresh(newMatrix: matrix, chart: view, invalidate: true)
@@ -84,6 +84,7 @@ open class AnimatedZoomViewJob: AnimatedViewPortJob
     
     internal override func animationEnd()
     {
+        guard let view = view else { return }
         (view as? BarLineChartViewBase)?.calculateOffsets()
         view.setNeedsDisplay()
     }

--- a/Source/Charts/Jobs/MoveViewJob.swift
+++ b/Source/Charts/Jobs/MoveViewJob.swift
@@ -17,12 +17,13 @@ open class MoveViewJob: ViewPortJob
 {
     open override func doJob()
     {
+        guard let viewPortHandler = viewPortHandler, let view = view else { return }
         var pt = CGPoint(
             x: xValue,
             y: yValue
         )
         
-        transformer.pointValueToPixel(&pt)
+        transformer?.pointValueToPixel(&pt)
         viewPortHandler.centerViewPort(pt: pt, chart: view)
     }
 }

--- a/Source/Charts/Jobs/ViewPortJob.swift
+++ b/Source/Charts/Jobs/ViewPortJob.swift
@@ -17,11 +17,11 @@ import CoreGraphics
 open class ViewPortJob: NSObject
 {
     internal var point: CGPoint = .zero
-    internal unowned var viewPortHandler: ViewPortHandler
+    internal weak var viewPortHandler: ViewPortHandler?
     internal var xValue = 0.0
     internal var yValue = 0.0
-    internal unowned var transformer: Transformer
-    internal unowned var view: ChartViewBase
+    internal weak var transformer: Transformer?
+    internal weak var view: ChartViewBase?
 
     @objc public init(
         viewPortHandler: ViewPortHandler,

--- a/Source/Charts/Jobs/ZoomViewJob.swift
+++ b/Source/Charts/Jobs/ZoomViewJob.swift
@@ -44,6 +44,7 @@ open class ZoomViewJob: ViewPortJob
     
     open override func doJob()
     {
+        guard let viewPortHandler = viewPortHandler, let view = view else { return }
         var matrix = viewPortHandler.setZoom(scaleX: scaleX, scaleY: scaleY)
         viewPortHandler.refresh(newMatrix: matrix, chart: view, invalidate: false)
         
@@ -55,7 +56,7 @@ open class ZoomViewJob: ViewPortJob
             y: CGFloat(yValue + yValsInView / 2.0)
         )
         
-        transformer.pointValueToPixel(&pt)
+        transformer?.pointValueToPixel(&pt)
         
         matrix = viewPortHandler.translate(pt: pt)
         viewPortHandler.refresh(newMatrix: matrix, chart: view, invalidate: false)


### PR DESCRIPTION
Convert `unowned` member variables in ViewPortJob to `weak optional` to get rid of crash in `AnimatedViewPortJob`